### PR TITLE
Added link to ACM Demo Video

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ KRM = the Kubernetes Resource Model
 *   [Solution Guide - Safe Rollouts with Anthos Config Management - Google Cloud](https://cloud.google.com/solutions/safe-rollouts-with-anthos-config-management)
 *   [Solution Guide - Best practices for policy management with Anthos Config Management and GitLab](https://cloud.google.com/solutions/best-practices-for-policy-management-with-anthos-config-management) - Google Cloud 
 *   [Solution Guide - Validating apps against company policies in a CI pipeline ](https://cloud.google.com/anthos-config-management/docs/tutorials/app-policy-validation-ci-pipeline)- Google Cloud 
-*   [Solution Guide - Managing cloud infrastructure using kpt ](https://cloud.google.com/solutions/managing-cloud-infrastructure-using-kpt) - Google Cloud 
+*   [Solution Guide - Managing cloud infrastructure using kpt ](https://cloud.google.com/solutions/managing-cloud-infrastructure-using-kpt) - Google Cloud
+*   [Video - Using Source Code Management Patterns To Configure And Secure Your Kubernetes Clusters](https://jwp.io/s/Or4kct75) - Giovanni Galloro, Google
 
 
 ## 🌊 Deep Dives 


### PR DESCRIPTION
Added a link to a video recording i did at Codemotion (a Dev Conference) where I explained ACM components and showed how to use ACM config-sync to prepare 'landing zones' (namespaces, rbac, quotas, network policies) for multitenant clusters (GKE and EKS), how to implement an approval process through pull requests and how to use ACM Policy Controller to implement a constraint on allowed container registry.

Have also the demo assets here: https://github.com/ggalloro/acm-workshop but still need to polish the documentation.
